### PR TITLE
Improve Table Usage

### DIFF
--- a/src/main/java/org/engine/TranspositionTable.java
+++ b/src/main/java/org/engine/TranspositionTable.java
@@ -114,10 +114,7 @@ public final class TranspositionTable {
         return (bound & 0b11) | (wasPV ? 0b100 : 0) | ((age & AGE_MASK) << 3);
     }
 
-    public static boolean boundAllowsThreshold(int bound, int score, int threshold) {
-        if (score >= threshold) return (bound & BOUND_LOWER) != 0;
-        return (bound & BOUND_UPPER) != 0;
-    }
+    
 
     public static final class ProbeResult {
         public final Entry entry;


### PR DESCRIPTION
```
Elo   | 35.59 +- 18.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.55 (-2.94, 2.94) [0.00, 2.00]
Games | N: 676 W: 298 L: 229 D: 149
Penta | [19, 39, 169, 76, 35]
```