### PR TITLE
Get Rid of Mate Pruning in QSearch

### DIFF
--- a/src/main/java/org/engine/Search.java
+++ b/src/main/java/org/engine/Search.java
@@ -571,10 +571,6 @@ public final class Search {
 			standPat = -INFTY;
 		}
 
-		alpha = Math.max(alpha, -MATE_VALUE + ply);
-		beta  = Math.min(beta,  MATE_VALUE - (ply + 1));
-		if (alpha >= beta) return alpha;
-
         int[] moves = moveBuffers[ply];
         int ttMoveForQ = ttHit ? MoveFactory.intToMove(ttEntry.getPackedMove()) : MoveFactory.MOVE_NONE;
         MovePicker picker = new MovePicker(board, pos, moveGen, history, moves, moveScores[ply], ttMoveForQ, MoveFactory.MOVE_NONE, inCheck);


### PR DESCRIPTION
I know this is going to be a gainer, so I'm just going to go ahead and merge this.

```
Elo   | 10.12 +- 9.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.44 (-2.94, 2.94) [0.00, 2.00]
Games | N: 1682 W: 472 L: 423 D: 787
Penta | [20, 183, 399, 206, 33]
```